### PR TITLE
Added option to specify the set of special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@
 | minschars  |   Minimum special characters in the password         | 1 |
 
 
+## Update V2.2.1
+Added option to specify the set of special characters
+
+example:
+``` python
+  pwo = PasswordGenerator()
+
+  pwo.minschars = 1
+  pwo.includeschars = "!$%^" # (Optional)
+```
+
 ## Update V2.2.0
 Application is now minimal(No dependencies). The API and WEB version are moved to https://github.com/suryasr007/rpg-web
 

--- a/password_generator.py
+++ b/password_generator.py
@@ -47,11 +47,12 @@ class PasswordGenerator:
         self.excludelchars = ""
         self.excludenumbers = ""
         self.excludeschars = ""
+        self.includeschars = ""
 
         self.lower_chars = string.ascii_lowercase
         self.upper_chars = string.ascii_uppercase
         self.numbers_list = string.digits
-        self._schars = [
+        self.schars = [
             "!",
             "#",
             "$",
@@ -71,12 +72,6 @@ class PasswordGenerator:
             ">",
             "?",
         ]
-        self._allchars = (
-            list(self.lower_chars)
-            + list(self.upper_chars)
-            + list(self.numbers_list)
-            + self._schars
-        )
 
     def generate(self):
         """Generates a password using default or custom properties"""
@@ -90,10 +85,15 @@ class PasswordGenerator:
         ):
             raise ValueError("Character length should not be negative")
 
+        if (len(self.excludeschars) and len(self.includeschars)):
+            raise ValueError("You can not specify both excludeschars and includeschars.")
+
         if self.minlen > self.maxlen:
             raise ValueError(
                 "Minimum length cannot be greater than maximum length. The default maximum length is 16."
             )
+
+        self.generate_allchars()
 
         collectiveMinLength = (
             self.minuchars + self.minlchars + self.minnumbers + self.minschars
@@ -115,13 +115,13 @@ class PasswordGenerator:
             for i in range(self.minnumbers)
         ]
         final_pass += [
-            choice(list(set(self._schars) - set(self.excludeschars)))
+            choice(list(set(self.schars) - set(self.excludeschars)))
             for i in range(self.minschars)
         ]
 
         currentpasslen = len(final_pass)
         all_chars = list(
-            set(self._allchars)
+            set(self.allchars)
             - set(
                 list(self.excludelchars)
                 + list(self.excludeuchars)
@@ -137,6 +137,16 @@ class PasswordGenerator:
         shuffle(final_pass)
         return "".join(final_pass)
 
+    def generate_allchars(self):
+        if len(self.includeschars):
+            self.schars = list(self.includeschars)
+        self.allchars = (
+            list(self.lower_chars)
+            + list(self.upper_chars)
+            + list(self.numbers_list)
+            + self.schars
+        )
+
     def shuffle_password(self, password, maxlen):
         """Shuffle the given charactes and return a password from given characters."""
         final_pass = [choice(list(password)) for i in range(int(maxlen))]
@@ -145,7 +155,7 @@ class PasswordGenerator:
 
     def non_duplicate_password(self, maxlen):
         """Generate a non duplicate key of given length"""
-        allchars = deepcopy(self._allchars)
+        allchars = deepcopy(self.allchars)
         final_pass = []
         try:
             for i in range(maxlen):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 from os import path
 
 
-VERSION = 'v2.2.0'
+VERSION = 'v2.2.1'
 
 here = path.abspath(path.dirname(__file__))
 

--- a/tests.py
+++ b/tests.py
@@ -26,6 +26,12 @@ class TestRPG(unittest.TestCase):
         pg.excludeuchars="A"
         self.assertNotIn("A",pg.generate())
 
+    def test_include_schars(self):
+        """Test generate() for specific special chars"""
+        pg = PasswordGenerator()
+        pg.minschars = 1
+        pg.includeschars = "["
+        self.assertIn("[",pg.generate())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi,

We are using your password generator to create random passwords for OwnCloud accounts using their password policy. By adding the option to specify the special characters we have 100% compatibility.

![oc_password_policy](https://user-images.githubusercontent.com/23337494/128160131-09eabd5a-c35f-4f08-9afb-75bdbbd08431.png)

Best regards,
Jean-Marie de Boer.